### PR TITLE
Simpler CookieStore: use Type.from_json

### DIFF
--- a/src/cookie_store.cr
+++ b/src/cookie_store.cr
@@ -2,32 +2,18 @@ module Crul
   class CookieStore
     getter :filename
 
-    def initialize
-      @cookies = {} of String => Hash
-    end
+    alias Cookies = Hash(String, Hash(String, String))
 
     def load(filename)
       @filename = filename
 
       return unless File.exists?(filename)
 
-      data = JSON.parse(File.read(filename))
-      if data.is_a?(Hash)
-        data.each do |host, cookies|
-          if host.is_a?(String) && cookies.is_a?(Hash)
-            @cookies[host] = {} of String => String
-            cookies.each do |name, cookie|
-              if name.is_a?(String) && cookie.is_a?(String)
-                @cookies[host][name] = cookie
-              end
-            end
-          end
-        end
-      end
+      @cookies = Cookies.from_json(File.read(filename))
     end
 
     def add_to_headers(host, port, headers)
-      if cookies = @cookies["#{host}:#{port}"]?
+      if cookies = cookies["#{host}:#{port}"]?
         cookies.each do |name, cookie|
           headers["Cookie"] = cookie
         end
@@ -36,14 +22,14 @@ module Crul
 
     def store_cookies(host, port, headers)
       if cookie_header = headers["Set-Cookie"]?
-        @cookies["#{host}:#{port}"] ||= {} of String => String
-        @cookies["#{host}:#{port}"][cookie_name(cookie_header)] = cookie_header
+        cookies["#{host}:#{port}"] ||= {} of String => String
+        cookies["#{host}:#{port}"][cookie_name(cookie_header)] = cookie_header
       end
     end
 
     def write!
       if filename = @filename
-        json = @cookies.to_json
+        json = cookies.to_json
         Dir.mkdir_p(File.dirname(filename))
         File.write(filename, json)
       end
@@ -51,6 +37,10 @@ module Crul
 
     private def cookie_name(cookie_header)
       cookie_header.split('=', 2).first
+    end
+
+    private def cookies
+      @cookies ||= Cookies.new
     end
   end
 end


### PR DESCRIPTION
Besides `JSON.parse` you can use a `Type.from_json`. For example:

``` crystal
require "json"

Array(Int32).from_json("[1, 2, 3]") #=> [1, 2, 3]
Array(Int32).from_json("123") # raises
```

In your code @cookies is `Hash(String, Hash(String, String))`, so you can do `Hash(String, Hash(String, String)).from_json(...)`. Because that's a bit long, I moved it to an `alias`. Then I made `@cookies` be lazily initialized.

These changes are just to reduce the amount of code, no funcionality is added.

Alternatively you could do:

``` crystal
class CookieStore
  def initialize
    @cookies = {} of String => Hash(String, String)
  end

  def load(filename)
    @filename = filename

    return unless File.exists?(filename)

    @cookies = typeof(@cookies).from_json(File.read(filename))
  end
end
```

but that creates an extra hash for nothing. Not really a big deal :-)

For more complex mappings you can look at [this](https://github.com/manastech/crystal/blob/master/spec/std/json/mapping_spec.cr).
