### PR TITLE
Crystal 0.20

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ release
 .deps
 *.zip
 libs
+lib
 .shards
 build/

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ You don't need this if you installed via Homebrew (it's automatic).
 
 ## Development
 
-You'll need [Crystal 0.19](http://crystal-lang.org/docs/installation/index.html) installed (it might work with older
+You'll need [Crystal 0.20](http://crystal-lang.org/docs/installation/index.html) installed (it might work with older
 or newer versions, but that's the one that's tested).
 
 After checking out the repo (or decompressing the tarball with the source code), run `shards` to get

--- a/shard.lock
+++ b/shard.lock
@@ -6,5 +6,5 @@ shards:
 
   webmock:
     github: manastech/webmock.cr
-    commit: 7c7ad8303dd9d65a60accd24deb0982255c42b44
+    commit: d7e2de5aa15b3f1940a873e6efc68d2203b801e1
 

--- a/spec/formatters/auto_spec.cr
+++ b/spec/formatters/auto_spec.cr
@@ -3,7 +3,7 @@ require "../spec_helper"
 describe Crul::Formatters::Auto do
   describe "#formatter" do
     it "detects JSON" do
-      output = MemoryIO.new
+      output = IO::Memory.new
       response = FakeResponse.new(content_type: "application/json")
       formatter = Crul::Formatters::Auto.new(output, response)
 
@@ -11,7 +11,7 @@ describe Crul::Formatters::Auto do
     end
 
     it "detects XML" do
-      output = MemoryIO.new
+      output = IO::Memory.new
       response = FakeResponse.new(content_type: "application/xml")
       formatter = Crul::Formatters::Auto.new(output, response)
 
@@ -19,7 +19,7 @@ describe Crul::Formatters::Auto do
     end
 
     it "defaults to plain" do
-      output = MemoryIO.new
+      output = IO::Memory.new
       response = FakeResponse.new(content_type: "text/csv")
       formatter = Crul::Formatters::Auto.new(output, response)
 
@@ -27,7 +27,7 @@ describe Crul::Formatters::Auto do
     end
 
     it "works without a header" do
-      output = MemoryIO.new
+      output = IO::Memory.new
       response = FakeResponse.new
       formatter = Crul::Formatters::Auto.new(output, response)
 
@@ -35,7 +35,7 @@ describe Crul::Formatters::Auto do
     end
 
     it "works with an encoding" do
-      output = MemoryIO.new
+      output = IO::Memory.new
       response = FakeResponse.new(content_type: "application/xml; charset=ISO-8859-1")
       formatter = Crul::Formatters::Auto.new(output, response)
 

--- a/spec/formatters/json_spec.cr
+++ b/spec/formatters/json_spec.cr
@@ -4,7 +4,7 @@ describe Crul::Formatters::JSON do
   describe "#print" do
     context "with valid JSON" do
       it "formats it" do
-        output = MemoryIO.new
+        output = IO::Memory.new
         response = FakeResponse.new("{\"a\":1}")
         formatter = Crul::Formatters::JSON.new(output, response)
 
@@ -16,7 +16,7 @@ describe Crul::Formatters::JSON do
 
     context "with invalid JSON" do
       it "formats it (falling back to plain)" do
-        output = MemoryIO.new
+        output = IO::Memory.new
         response = FakeResponse.new("{{{")
         formatter = Crul::Formatters::JSON.new(output, response)
 

--- a/spec/formatters/plain_spec.cr
+++ b/spec/formatters/plain_spec.cr
@@ -3,7 +3,7 @@ require "../spec_helper"
 describe Crul::Formatters::Plain do
   describe "#print" do
     it "prints" do
-      output = MemoryIO.new
+      output = IO::Memory.new
       response = FakeResponse.new("Hello")
       formatter = Crul::Formatters::Plain.new(output, response)
 

--- a/spec/formatters/xml_spec.cr
+++ b/spec/formatters/xml_spec.cr
@@ -4,7 +4,7 @@ describe Crul::Formatters::XML do
   describe "#print" do
     context "with valid XML" do
       it "formats it" do
-        output = MemoryIO.new
+        output = IO::Memory.new
         response = FakeResponse.new("<a><b>c</b></a>")
         formatter = Crul::Formatters::XML.new(output, response)
 
@@ -17,7 +17,7 @@ describe Crul::Formatters::XML do
 
     context "with malformed XML" do
       it "formats it (falling back to plain)" do
-        output = MemoryIO.new
+        output = IO::Memory.new
         response = FakeResponse.new("<<<")
         formatter = Crul::Formatters::XML.new(output, response)
 

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -19,7 +19,7 @@ abstract class Crul::Formatters::Base
 end
 
 def capture_lines(&block)
-  output = MemoryIO.new
+  output = IO::Memory.new
   yield(output)
   output.to_s.strip.split("\n")
 end


### PR DESCRIPTION
Minimal changes needed to compile and work in Crystal 0.20. There are two deprecation warnings remaining that are likely happening in some dependency.