### PR TITLE
Fix colorize stream target

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -6,5 +6,5 @@ shards:
 
   webmock:
     github: manastech/webmock.cr
-    commit: d7e2de5aa15b3f1940a873e6efc68d2203b801e1
+    commit: c673f393a31eac2734c7599897357ef1f3f24011
 

--- a/spec/integration/basic_spec.cr
+++ b/spec/integration/basic_spec.cr
@@ -30,6 +30,18 @@ describe "Basic examples" do
     lines.last.should eq("Hello")
   end
 
+  it "colorizes output" do
+    WebMock.stub(:get, "http://example.org/").to_return(body: "Hello", headers: {"Hello" => "World"})
+
+    lines = capture_lines(uncolorize?: false) do |output|
+      Crul::CLI.run!(["http://example.org"], output).should be_true
+    end
+
+    lines.first.should eq("\e[94mHTTP/1.1\e[0m\e[36m 200 \e[0m\e[33mOK")
+    lines[2].should eq("\e[0mHello: \e[36mWorld")
+    lines.last.should eq("Hello")
+  end
+
   it "most basic GET with https" do
     WebMock.stub(:get, "https://example.org/").to_return(body: "Hello")
 

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -18,10 +18,12 @@ abstract class Crul::Formatters::Base
   end
 end
 
-def capture_lines(&block)
+def capture_lines(uncolorize? = true, &block)
   output = IO::Memory.new
   yield(output)
-  output.to_s.strip.split("\n")
+  string = output.to_s
+  string = uncolorize(string) if uncolorize?
+  string.strip.split("\n")
 end
 
 Spec.before_each do

--- a/src/command.cr
+++ b/src/command.cr
@@ -42,13 +42,13 @@ module Crul
     end
 
     private def print_response(response)
-      with_color.light_blue.surround { @output << response.version }
-      with_color.cyan.surround { @output << " #{response.status_code} " }
-      with_color.yellow.surround { @output.puts response.status_message }
+      with_color.light_blue.surround(@output) { |io| io << response.version }
+      with_color.cyan.surround(@output) { |io| io << " #{response.status_code} " }
+      with_color.yellow.surround(@output) { |io| io.puts response.status_message }
       response.headers.each do |name, values|
         values.each do |value|
           @output << "#{name}: "
-          with_color.cyan.surround { @output.puts value }
+          with_color.cyan.surround(@output) { |io| io.puts value }
         end
       end
       @output.puts


### PR DESCRIPTION
Colorize's `surround` method uses `STDOUT` by default, if command's output is a different `IO`, then ANSI escape codes would still be printed to `STDOUT` and contents to `@output`.

Includes updated spec helper `capture_lines` wich calls `uncolorize` by default.
Updates Webmock to latest version c673f393 because specs would not run with old version.