### PR TITLE
Add autodetection for JSON API

### DIFF
--- a/spec/formatters/auto_spec.cr
+++ b/spec/formatters/auto_spec.cr
@@ -10,6 +10,14 @@ describe Crul::Formatters::Auto do
       formatter.formatter.should be_a(Crul::Formatters::JSON)
     end
 
+    it "detects JSONAPI" do
+      output = IO::Memory.new
+      response = FakeResponse.new(content_type: "application/vnd.api+json")
+      formatter = Crul::Formatters::Auto.new(output, response)
+
+      formatter.formatter.should be_a(Crul::Formatters::JSON)
+    end
+
     it "detects XML" do
       output = IO::Memory.new
       response = FakeResponse.new(content_type: "application/xml")

--- a/src/formatters/auto.cr
+++ b/src/formatters/auto.cr
@@ -8,7 +8,7 @@ module Crul
       def initialize(output, response)
         content_type = response.headers.fetch("Content-type", "text/plain").split(';').first
         formatter_class = case content_type
-                          when "application/json"
+                          when "application/json", "application/vnd.api+json"
                             JSON
                           when "application/xml"
                             XML


### PR DESCRIPTION
This PR lets the auto formatter know about the JSON API content type `application/vnd.api+json` (as defined per http://jsonapi.org/format/#introduction).