### PR TITLE
Reorganize option parsing for Crystal 0.23 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Bug on colorizing output ([#22](https://github.com/porras/crul/pull/22), thanks [straight-shoota](https://github.com/straight-shoota))
 
+### Other
+- Crystal 0.23 compatibility ([#24](https://github.com/porras/crul/pull/24)
+
 ## [0.4.1](https://github.com/porras/crul/compare/0.4.0...0.4.1)
 ### Fixed
 - Bug on formatting floats ([#18](https://github.com/porras/crul/issues/18))

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ You don't need this if you installed via Homebrew (it's automatic).
 
 ## Development
 
-You'll need [Crystal 0.20](http://crystal-lang.org/docs/installation/index.html) installed (it might work with older
+You'll need [Crystal 0.23](http://crystal-lang.org/docs/installation/index.html) installed (it might work with older
 or newer versions, but that's the one that's tested).
 
 After checking out the repo (or decompressing the tarball with the source code), run `shards` to get

--- a/src/crul.cr
+++ b/src/crul.cr
@@ -4,7 +4,7 @@ module Crul
       options = Options.parse(argv)
 
       if options.help?
-        output.puts options.parser
+        output.puts Options::USAGE
         return true
       end
 
@@ -14,7 +14,7 @@ module Crul
       end
 
       if options.errors.any?
-        output.puts options.parser
+        output.puts Options::USAGE
 
         output.puts "Errors:"
         options.errors.each do |error|

--- a/src/options.cr
+++ b/src/options.cr
@@ -22,19 +22,52 @@ module Crul
       @errors = [] of Exception
     end
 
+    USAGE = <<-USAGE
+      Usage: crul [method] URL [options]
+
+      HTTP methods (default: GET):
+        get, GET                         Use GET
+        post, POST                       Use POST
+        put, PUT                         Use PUT
+        delete, DELETE                   Use DELETE
+
+      HTTP options:
+        -d DATA, --data DATA             Request body
+        -d @file, --data @file           Request body (read from file)
+        -H HEADER, --header HEADER       Set header
+        -a USER:PASS, --auth USER:PASS   Basic auth
+        -c FILE, --cookies FILE          Use FILE as cookie store (reads and writes)
+
+      Response formats (default: autodetect):
+        -j, --json                       Format response as JSON
+        -x, --xml                        Format response as XML
+        -p, --plain                      Format response as plain text
+
+      Other options:
+        -h, --help                       Show this help
+        -V, --version                    Display version
+    USAGE
+
     def self.parse(args)
       new.tap do |options|
+        case args.first?
+        when "get", "GET"
+          args.shift
+          options.method = Methods::GET
+        when "post", "POST"
+          args.shift
+          options.method = Methods::POST
+        when "put", "PUT"
+          args.shift
+          options.method = Methods::PUT
+        when "delete", "DELETE"
+          args.shift
+          options.method = Methods::DELETE
+        else # it's the default
+          options.method = Methods::GET
+        end
+
         options.parser = OptionParser.parse(args) do |parser|
-          parser.banner = "Usage: crul [method] URL [options]"
-
-          parser.separator
-          parser.separator "HTTP methods (default: GET):"
-          parser.on("get", "GET", "Use GET") { options.method = Methods::GET }
-          parser.on("post", "POST", "Use POST") { options.method = Methods::POST }
-          parser.on("put", "PUT", "Use PUT") { options.method = Methods::PUT }
-          parser.on("delete", "DELETE", "Use DELETE") { options.method = Methods::DELETE }
-
-          parser.separator
           parser.separator "HTTP options:"
           parser.on("-d DATA", "--data DATA", "Request body") do |body|
             options.body = if body.starts_with?('@')


### PR DESCRIPTION
Not amazed with the solution but works. It can be refactored in the future. (Also, [the Crystal compiler](https://github.com/crystal-lang/crystal/blob/fcce0c2ec1e65113308189fb745cf8c118939d60/src/compiler/crystal/command.cr) does something very similar).