### PR TITLE
Fixes for Crystal 0.26.1

### DIFF
--- a/crul.cr
+++ b/crul.cr
@@ -1,6 +1,6 @@
 require "./src/*"
 
-Crul::Completion.setup
+# Crul::Completion.setup
 
 if Crul::CLI.run!(ARGV, STDOUT)
   exit

--- a/shard.lock
+++ b/shard.lock
@@ -6,5 +6,5 @@ shards:
 
   webmock:
     github: manastech/webmock.cr
-    commit: c673f393a31eac2734c7599897357ef1f3f24011
+    commit: ca7c79ab3cc8b4c56cb1d70ba7a6952dc35ef8f6
 

--- a/spec/integration/basic_spec.cr
+++ b/spec/integration/basic_spec.cr
@@ -26,7 +26,7 @@ describe "Basic examples" do
     end
 
     lines.first.should eq("HTTP/1.1 200 OK")
-    lines[2].should eq("Hello: World")
+    lines.should contain("Hello: World")
     lines.last.should eq("Hello")
   end
 
@@ -38,7 +38,7 @@ describe "Basic examples" do
     end
 
     lines.first.should eq("\e[94mHTTP/1.1\e[0m\e[36m 200 \e[0m\e[33mOK")
-    lines[2].should eq("\e[0mHello: \e[36mWorld")
+    lines.should contain("\e[0mHello: \e[36mWorld")
     lines.last.should eq("Hello")
   end
 


### PR DESCRIPTION
Fixes #25.

Changes:

* The webmock dependency was broken. Updating it fixed it
* A small change in webmock had broken a couple of specs that were a bit coupled. The fix was very easy
* Disable (hopefully as a temporary measure) the bash completion generator, as the dependency that provides it is broken and apparently unmantained